### PR TITLE
Python: Heap

### DIFF
--- a/Python/Leetcode75/Medium/Heap/Q2462-TotalCostToHireKWorkers.py
+++ b/Python/Leetcode75/Medium/Heap/Q2462-TotalCostToHireKWorkers.py
@@ -1,0 +1,46 @@
+import heapq
+
+class Solution:
+    def totalCost(self, costs: List[int], k: int, c: int) -> int:
+        min_cost = 0
+        n = len(costs)
+        l_heap, r_heap = [], []
+
+        l_ptr, r_ptr = 0, n - 1
+
+        for i in range(min(c, n)):
+            heapq.heappush(l_heap, (costs[l_ptr], l_ptr))
+            l_ptr += 1
+        
+        for j in range(min(c, n)):
+            if r_ptr >= l_ptr:
+                heapq.heappush(r_heap, (costs[r_ptr], r_ptr))
+                r_ptr -= 1
+
+        while k > 0:
+            if l_heap and r_heap:
+                if l_heap[0][0] <= r_heap[0][0]:
+                    cost, _ = heapq.heappop(l_heap)
+                    if l_ptr <= r_ptr:
+                        heapq.heappush(l_heap, (costs[l_ptr], l_ptr))
+                        l_ptr += 1
+                else:
+                    cost, _ = heapq.heappop(r_heap)
+                    if l_ptr <= r_ptr:
+                        heapq.heappush(r_heap, (costs[r_ptr], r_ptr))
+                        r_ptr -= 1
+            elif l_heap:
+                cost, _ = heapq.heappop(l_heap)
+                if l_ptr <= r_ptr:
+                    heapq.heappush(l_heap, (costs[l_ptr], l_ptr))
+                    l_ptr += 1
+            elif r_heap:
+                cost, _ = heapq.heappop(r_heap)
+                if l_ptr <= r_ptr:
+                    heapq.heappush(r_heap, (costs[r_ptr], r_ptr))
+                    r_ptr -= 1
+            
+            min_cost += cost
+            k -= 1
+
+        return min_cost

--- a/Python/Weekly/W419/3318-FindXSumOfAllKLongSubarraysI.py
+++ b/Python/Weekly/W419/3318-FindXSumOfAllKLongSubarraysI.py
@@ -1,0 +1,10 @@
+class Solution:
+    def findXSum(self, nums: List[int], k: int, x: int) -> List[int]:
+        ans = []
+
+        for i in range(len(nums) - k + 1):
+            c = [[cnt, val] for val, cnt in Counter(nums[i:i+k]).items()]
+            c = heapq.nlargest(x, c)
+            ans.append(sum(val * cnt for val, cnt in c))
+
+        return ans


### PR DESCRIPTION
- **Python/Weekly/W416: Q3295-ReportSpamMessage, Q3296-MinimumNumberOfSecondsToMakeMountainHeightZero**
- **Python/Easy/Array: Q1403-MinimumSubsequenceInNonIncreasingOrder, Q1566-DetectPatternOfLengthMRepeatedKOrMoreTimes, Q1886-DetermineWhetherMatrixCanBeObtainedByRotation**
- **Python/Easy/Array: Q3190-FindMinimumOperationsToMakeAllElementsDivisibleByThree, Q3194-MinimumAverageOfSmallestAndLargestElements, Q3285-FindIndicesOfStableMountains**
- **Python/Easy/Array: Q2828-CheckIfAStringIsAnAcronymOfWords, Q3232-FindIfDigitGameCanBeWon, Q3242-DesignNeighborSumService**
- **Python/Medium/Array: Q54-SpiralMatrix, Q59-SpiralMatrixII, Q885-SpiralMatrixIII**
- **Python/Easy/Array: Q1893-CheckIfAllTheIntegersInARangeAreCovered, Q1913-MaximumProductDifferenceBetweenTwoPairs, Q1961-CheckIfStringIsAPrefixOfArray, Q1967-NumberOfStringsThatAppearAsSubstringsInWord, Q1979-FindGreatestCommonDivisorOfArray**
- **Python/Medium/Array: Q729-MyCalendarI, Q950-RevealCardsInIncreasingOrder, Q1605-FindValidMatrixGivenRowAndColumnSums**
- **Python/Easy/Array: Q1984-MinimumDifferenceBetweenHighestAndLowestOfKScores, Q1991-FindTheMiddleIndexInArray, Q2022-Convert1DArrayInto2DArray**
- **Python/Medium/Backtrack: Q39-CombinationSum, Q46-Permutations**
- **Python/Medium/Array: Q731-MyCalendarII**
- **Python: added README.md**
- **Python/Medium/Queue: Q641-DesignCircularDeque**
- **Python/LeetCode75/Easy/String: Q1071-GreatestCommonDivisorOfStrings, Q1768-MergeStringsAlternately**
- **Python/LeetCode75/Easy/String: Q345-ReverseVowelsOfAString**
- **Python/LeetCode75/Easy/Array: Q605-CanPlaceFlowers, Q1431-KidsWithTheGreatestNumberOfCandies**
- **Python/LeetCode75/Medium/Backtrack: Q216-CombinationSumIII**
- **Python/LeetCode75/Easy/TwoPointer: Q283-MoveZeroes, Q392-IsSubsequence**
- **Python/LeetCode75/Medium/Array: Q238-ProductOfArrayExceptSelf**
- **Python/LeetCode75/Medium/String: Q151-ReverseWordsInAString**
- **Python/Weekly/W417: Q3304-FindTheKthCharacterInStringGameI, Q3305-CountOfSubstringsContainingEveryVowelAndKConsonantsI**
- **Python/LeetCode75/Easy/PrefixSum: Q724-FindPivotIndex, Q1732-FindTheHighestAltitude**
- **Python/LeetCode75/Easy/SlidingWindow: Q643-MaximumAverageSubarrayI**
- **Python/LeetCode75/Medium/TwoPointer: Q11-ContainerWithMostWater, Q1679-MaxNumberOfKSumPairs**
- **Python/LeetCode75/Easy/Hashmap: Q1207-UniqueNumberOfOccurrences, Q2215-FindTheDifferenceOfTwoArrays**
- **Python/LeetCode75/Medium/String: Q443-StringCompression**
- **Python/LeetCode75/Medium/SlidingWindow: Q1004-MaxConsecutiveOnesIII, Q1456-MaximumNumberOfVowelsInASubstringOfGivenLength**
- **Python/LeetCode75/Medium/SlidingWindow: Q1493-LongestSubarrayOf1sAfterDeletingOneElement**
- **Python/LeetCode75/Medium/Hashmap: Q1657-DetermineIfTwoStringsAreClose, Q2352-EqualRowAndColumnPairs**
- **Python/LeetCode75/Medium/Stack: Q394-DecodeString, Q735-AsteroidCollision, Q2390-RemovingStarsFromAString**
- **Python/LeetCode75/Easy/Queue: Q933-NumberOfRecentCalls**
- **Python/LeetCode75/Easy/LinkedList: Q206-ReverseLinkedList**
- **Python/LeetCode75/Easy/BinaryTree: Q104-MaximumDepthOfBinaryTree, Q872-LeafSimilarTrees**
- **Python/LeetCode75/Medium/LinkedList: Q328-OddEvenLinkedList, Q2095-DeleteTheMiddleNodeOfALinkedList, Q2130-MaximumTwinSumOfALinkedList**
- **Python/LeetCode75/Easy/BinarySearchTree: Q700-SearchInABinarySearchTree**
- **Python/LeetCode75/Medium/BinarySearchTree: Q450-DeleteNodeInABST**
- **Python/LeetCode75/Medium/BinaryTreeBFS: Q199-BinaryTreeRightSideView, Q1161-MaximumLevelSumOfABinaryTree**
- **Python/LeetCode75/Easy/BinarySearch: Q374-GuessNumberHigherOrLower**
- **Python/LeetCode75/Easy/DP1D: Q746-MinCostClimbingStairs, Q1137-NthTribonacciNumber**
- **Python/LeetCode75/Medium/BinaryTreeDFS: Q236-LowestCommonAncestorOfABinaryTree, Q1372-LongestZigZagPathInABinaryTree, Q1448-CountGoodNodesInBinaryTree**
- **Python/LeetCode75/Medium/BinaryTreeDFS: Q437-PathSumIII**
- **Python/LeetCode75/Easy/BitManipulation: Q136-SingleNumber, Q338-CountingBits**
- **Python/LeetCode75/Medium/BitManipulation: Q1318-MinimumFlipToMakeaORbEqualToc**
- **Python/LeetCode75/Medium/Trie: Q208-ImplementTrie**
- **Python/Weekly/W418: Q3309-MaximumPossibleNumberByBinaryConcatenation, Q3310-RemoveMethodsFromProject**
- **Python/LeetCode75/Medium/BinarySearch: Q162-FindPeakElement, Q875-KokoEatingBananas, Q2300-SuccessfulPairsOfSpellsAndPotions**
- **Python/LeetCode75/Medium/DP1D: Q198-HouseRobber, Q790-DominoAndTrominoTiling**
- **Python/LeetCode75/Medium/GraphDFS: Q399-EvaluateDivision, Q547-NumberOfProvinces, Q841-KeysAndRooms, Q1466-ReorderRoutesToMakeAllPathsLeadToTheCityZero**
- **Python/LeetCode75/Medium/GraphBFS: Q994-RottingOranges, Q1926-NearestExitFromEntranceInMaze**
- **Python/LeetCode75/Medium/Queue: Q649-Dota2Senate**
- **Python/LeetCode75/Medium/Heap: Q215-KthLargestElementInAnArray, Q2336-SmallestNumberInInfiniteSet, Q2542-MaximumSubsequenceScore**
- **Python/Weekly/W419: 3318-FindXSumOfAllKLongSubarraysI**
- **Python/LeetCode75/Medium/Heap: Q2462-TotalCostToHireKWorkers**
