### PR TITLE
Python: DP and Array

### DIFF
--- a/Python/Leetcode75/Medium/Array/Q334-IncreasingTripletSubsequence.py
+++ b/Python/Leetcode75/Medium/Array/Q334-IncreasingTripletSubsequence.py
@@ -1,0 +1,12 @@
+class Solution:
+    def increasingTriplet(self, nums: List[int]) -> bool:
+        a = b = float('inf')
+
+        for n in nums:
+            if n <= a:
+                a = n
+            elif n <= b:
+                b = n
+            else:
+                return True
+        return False

--- a/Python/Leetcode75/Medium/Backtrack/Q17-LetterCombinationsOfAPhoneNumber.py
+++ b/Python/Leetcode75/Medium/Backtrack/Q17-LetterCombinationsOfAPhoneNumber.py
@@ -1,0 +1,31 @@
+class Solution:
+    def letterCombinations(self, digits: str) -> List[str]:
+        if not digits:
+            return []
+
+        m = {
+            "2": ["a", "b", "c"],
+            "3": ["d", "e", "f"],
+            "4": ["g", "h", "i"],
+            "5": ["j", "k", "l"],
+            "6": ["m", "n", "o"],
+            "7": ["p", "q", "r", "s"],
+            "8": ["t", "u", "v"],
+            "9": ["w", "x", "y", "z"],
+        }
+
+        combs = []
+
+        def backtrack(index, current):
+            if index == len(digits):
+                combs.append(current)
+                return
+
+            letters = m[digits[index]]
+
+            for letter in letters:
+                backtrack(index + 1, current + letter)
+
+        backtrack(0, "")
+
+        return combs

--- a/Python/Leetcode75/Medium/DPMultidensional/Q1143-LongestCommonSubsequence.py
+++ b/Python/Leetcode75/Medium/DPMultidensional/Q1143-LongestCommonSubsequence.py
@@ -1,0 +1,13 @@
+class Solution:
+    def longestCommonSubsequence(self, text1: str, text2: str) -> int:
+        m, n = len(text1), len(text2)
+        dp = [[0] * (n + 1) for _ in range(m + 1)]
+
+        for i in range(1, m + 1):
+            for j in range(1, n + 1):
+                if text1[i - 1] == text2[j - 1]:
+                    dp[i][j] = 1 + dp[i - 1][j - 1]
+                else:
+                    dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+                    
+        return dp[m][n]

--- a/Python/Leetcode75/Medium/DPMultidensional/Q714-BestTimeToBuyAndSellStockWithTransactionFee.py
+++ b/Python/Leetcode75/Medium/DPMultidensional/Q714-BestTimeToBuyAndSellStockWithTransactionFee.py
@@ -1,0 +1,10 @@
+class Solution:
+    def maxProfit(self, prices: List[int], fee: int) -> int:
+        cin_w = -prices[0]
+        cin_wo = 0
+
+        for i in range(len(prices)):
+            cin_w = max(cin_w, cin_wo - prices[i])
+            cin_wo = max(cin_wo, cin_w + prices[i] - fee)
+
+        return cin_wo


### PR DESCRIPTION
- **Python/Weekly/W416: Q3295-ReportSpamMessage, Q3296-MinimumNumberOfSecondsToMakeMountainHeightZero**
- **Python/Easy/Array: Q1403-MinimumSubsequenceInNonIncreasingOrder, Q1566-DetectPatternOfLengthMRepeatedKOrMoreTimes, Q1886-DetermineWhetherMatrixCanBeObtainedByRotation**
- **Python/Easy/Array: Q3190-FindMinimumOperationsToMakeAllElementsDivisibleByThree, Q3194-MinimumAverageOfSmallestAndLargestElements, Q3285-FindIndicesOfStableMountains**
- **Python/Easy/Array: Q2828-CheckIfAStringIsAnAcronymOfWords, Q3232-FindIfDigitGameCanBeWon, Q3242-DesignNeighborSumService**
- **Python/Medium/Array: Q54-SpiralMatrix, Q59-SpiralMatrixII, Q885-SpiralMatrixIII**
- **Python/Easy/Array: Q1893-CheckIfAllTheIntegersInARangeAreCovered, Q1913-MaximumProductDifferenceBetweenTwoPairs, Q1961-CheckIfStringIsAPrefixOfArray, Q1967-NumberOfStringsThatAppearAsSubstringsInWord, Q1979-FindGreatestCommonDivisorOfArray**
- **Python/Medium/Array: Q729-MyCalendarI, Q950-RevealCardsInIncreasingOrder, Q1605-FindValidMatrixGivenRowAndColumnSums**
- **Python/Easy/Array: Q1984-MinimumDifferenceBetweenHighestAndLowestOfKScores, Q1991-FindTheMiddleIndexInArray, Q2022-Convert1DArrayInto2DArray**
- **Python/Medium/Backtrack: Q39-CombinationSum, Q46-Permutations**
- **Python/Medium/Array: Q731-MyCalendarII**
- **Python: added README.md**
- **Python/Medium/Queue: Q641-DesignCircularDeque**
- **Python/LeetCode75/Easy/String: Q1071-GreatestCommonDivisorOfStrings, Q1768-MergeStringsAlternately**
- **Python/LeetCode75/Easy/String: Q345-ReverseVowelsOfAString**
- **Python/LeetCode75/Easy/Array: Q605-CanPlaceFlowers, Q1431-KidsWithTheGreatestNumberOfCandies**
- **Python/LeetCode75/Medium/Backtrack: Q216-CombinationSumIII**
- **Python/LeetCode75/Easy/TwoPointer: Q283-MoveZeroes, Q392-IsSubsequence**
- **Python/LeetCode75/Medium/Array: Q238-ProductOfArrayExceptSelf**
- **Python/LeetCode75/Medium/String: Q151-ReverseWordsInAString**
- **Python/Weekly/W417: Q3304-FindTheKthCharacterInStringGameI, Q3305-CountOfSubstringsContainingEveryVowelAndKConsonantsI**
- **Python/LeetCode75/Easy/PrefixSum: Q724-FindPivotIndex, Q1732-FindTheHighestAltitude**
- **Python/LeetCode75/Easy/SlidingWindow: Q643-MaximumAverageSubarrayI**
- **Python/LeetCode75/Medium/TwoPointer: Q11-ContainerWithMostWater, Q1679-MaxNumberOfKSumPairs**
- **Python/LeetCode75/Easy/Hashmap: Q1207-UniqueNumberOfOccurrences, Q2215-FindTheDifferenceOfTwoArrays**
- **Python/LeetCode75/Medium/String: Q443-StringCompression**
- **Python/LeetCode75/Medium/SlidingWindow: Q1004-MaxConsecutiveOnesIII, Q1456-MaximumNumberOfVowelsInASubstringOfGivenLength**
- **Python/LeetCode75/Medium/SlidingWindow: Q1493-LongestSubarrayOf1sAfterDeletingOneElement**
- **Python/LeetCode75/Medium/Hashmap: Q1657-DetermineIfTwoStringsAreClose, Q2352-EqualRowAndColumnPairs**
- **Python/LeetCode75/Medium/Stack: Q394-DecodeString, Q735-AsteroidCollision, Q2390-RemovingStarsFromAString**
- **Python/LeetCode75/Easy/Queue: Q933-NumberOfRecentCalls**
- **Python/LeetCode75/Easy/LinkedList: Q206-ReverseLinkedList**
- **Python/LeetCode75/Easy/BinaryTree: Q104-MaximumDepthOfBinaryTree, Q872-LeafSimilarTrees**
- **Python/LeetCode75/Medium/LinkedList: Q328-OddEvenLinkedList, Q2095-DeleteTheMiddleNodeOfALinkedList, Q2130-MaximumTwinSumOfALinkedList**
- **Python/LeetCode75/Easy/BinarySearchTree: Q700-SearchInABinarySearchTree**
- **Python/LeetCode75/Medium/BinarySearchTree: Q450-DeleteNodeInABST**
- **Python/LeetCode75/Medium/BinaryTreeBFS: Q199-BinaryTreeRightSideView, Q1161-MaximumLevelSumOfABinaryTree**
- **Python/LeetCode75/Easy/BinarySearch: Q374-GuessNumberHigherOrLower**
- **Python/LeetCode75/Easy/DP1D: Q746-MinCostClimbingStairs, Q1137-NthTribonacciNumber**
- **Python/LeetCode75/Medium/BinaryTreeDFS: Q236-LowestCommonAncestorOfABinaryTree, Q1372-LongestZigZagPathInABinaryTree, Q1448-CountGoodNodesInBinaryTree**
- **Python/LeetCode75/Medium/BinaryTreeDFS: Q437-PathSumIII**
- **Python/LeetCode75/Easy/BitManipulation: Q136-SingleNumber, Q338-CountingBits**
- **Python/LeetCode75/Medium/BitManipulation: Q1318-MinimumFlipToMakeaORbEqualToc**
- **Python/LeetCode75/Medium/Trie: Q208-ImplementTrie**
- **Python/Weekly/W418: Q3309-MaximumPossibleNumberByBinaryConcatenation, Q3310-RemoveMethodsFromProject**
- **Python/LeetCode75/Medium/BinarySearch: Q162-FindPeakElement, Q875-KokoEatingBananas, Q2300-SuccessfulPairsOfSpellsAndPotions**
- **Python/LeetCode75/Medium/DP1D: Q198-HouseRobber, Q790-DominoAndTrominoTiling**
- **Python/LeetCode75/Medium/GraphDFS: Q399-EvaluateDivision, Q547-NumberOfProvinces, Q841-KeysAndRooms, Q1466-ReorderRoutesToMakeAllPathsLeadToTheCityZero**
- **Python/LeetCode75/Medium/GraphBFS: Q994-RottingOranges, Q1926-NearestExitFromEntranceInMaze**
- **Python/LeetCode75/Medium/Queue: Q649-Dota2Senate**
- **Python/LeetCode75/Medium/Heap: Q215-KthLargestElementInAnArray, Q2336-SmallestNumberInInfiniteSet, Q2542-MaximumSubsequenceScore**
- **Python/Weekly/W419: 3318-FindXSumOfAllKLongSubarraysI**
- **Python/LeetCode75/Medium/Heap: Q2462-TotalCostToHireKWorkers**
- **Python/LeetCode75/Medium/MonotonicStack: Q739-DailyTemperatures, Q901-OnlineStockSpan**
- **Python/LeetCode75/Medium/Interval: Q435-NonOverlappingIntervals, Q452-MinimumNumberOfArrowsToBurstBalloons**
- **Python/LeetCode75/Medium/Trie: Q1268-SearchSuggestionsSystem**
- **Python/LeetCode75/Medium/DPMultidensional: Q62-UniquePaths, Q72-EditDistance**
- **Python/LeetCode75/Medium/Backtrack: Q17-LetterCombinationsOfAPhoneNumber**
- **Python/LeetCode75/Medium/DPMultidensional: Q714-BestTimeToBuyAndSellStockWithTransactionFee, Q1143-LongestCommonSubsequence**
- **Python/LeetCode75/Medium/Array: Q334-IncreasingTripletSubsequence**
